### PR TITLE
Add: github action workflow file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build qETRC
 
 on:
   push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:
@@ -24,7 +22,6 @@ jobs:
           libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 \
           libxcb-xfixes0 libxcb-xkb1 libxcb1 libxkbcommon-x11-0 libxkbcommon0 \
           libgl1-mesa-dev libglu1-mesa-dev
-
 
       - name: Install Qt using qt installer
         run: |
@@ -55,22 +52,28 @@ jobs:
           name: qETRC
           path: build/qETRC
 
-#       - name: Pack .deb
-#         run: |
-#           mkdir -p package/DEBIAN
-#           echo "Package: qETRC" > package/DEBIAN/control
-#           echo "Version: 1.0.0" >> package/DEBIAN/control
-#           echo "Section: base" >> package/DEBIAN/control
-#           echo "Priority: optional" >> package/DEBIAN/control
-#           echo "Architecture: amd64" >> package/DEBIAN/control
-#           echo "Maintainer: Your Name <your.email@example.com>" >> package/DEBIAN/control
-#           echo "Description: qETRC application" >> package/DEBIAN/control
-#           mkdir -p package/usr/local/bin
-#           cp build/qETRC package/usr/local/bin/
-#           dpkg-deb --build package qETRC-1.0.0.deb
-#
-#       - name: Upload .deb artifact
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: qETRC-deb
-#           path: qETRC-1.0.0.deb
+      - name: Pack .deb
+        run: |
+          mkdir -p package/DEBIAN
+          echo "Package: qETRC"       > package/DEBIAN/control
+          echo "Version: nightly"    >> package/DEBIAN/control
+          echo "Section: base"       >> package/DEBIAN/control
+          echo "Priority: optional"  >> package/DEBIAN/control
+          echo "Architecture: amd64" >> package/DEBIAN/control
+          echo "Maintainer: ${{ vars.MAINTAINER_NAME }} <${{ vars.MAINTAINER_EMAIL }}>" \
+                                     >> package/DEBIAN/control
+          echo "Description: qETRC is a feature-rich railway timetabling application" \
+                                     >> package/DEBIAN/control
+          mkdir -p package/usr/local/bin
+          mkdir -p package/usr/local/lib
+          # Use ldd here to get a whole list of dependencies. If the dependency is already
+          # available on the remote then ignore. Function WIP
+          cp build/qETRC package/usr/local/bin/
+          ldd package/usr/local/bin/qETRC
+          dpkg-deb --build package qETRC-nightly.deb
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qETRC-deb
+          path: qETRC-nightly.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build qETRC
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-linux-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # there are submodules in the repository
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+          libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 \
+          libxcb-xfixes0 libxcb-xkb1 libxcb1 libxkbcommon-x11-0 libxkbcommon0 \
+          libgl1-mesa-dev libglu1-mesa-dev
+
+
+      - name: Install Qt using qt installer
+        run: |
+          wget ${{ vars.QT_INSTALLER_URL }} -O qt-installer.run
+          chmod +x qt-installer.run
+          ./qt-installer.run --email ${{ secrets.QT_EMAIL }} --pw ${{ secrets.QT_PASSWORD }} \
+          --root $HOME/Qt --accept-licenses --default-answer --confirm-command --accept-obligations install qt6.7.0-full
+
+      - name: Build SARibbon
+        run: |
+          cd external/SARibbon
+          mkdir build
+          cd build
+          cmake .. -D CMAKE_PREFIX_PATH=$HOME/Qt/6.7.0/gcc_64
+          cmake --build .
+          sudo cmake --install .
+
+      - name: Build qETRC
+        run: |
+          mkdir build
+          cd build
+          cmake .. -D CMAKE_PREFIX_PATH=$HOME/Qt/6.7.0/gcc_64
+          cmake --build .
+
+      - name: Put to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qETRC
+          path: build/qETRC
+
+#       - name: Pack .deb
+#         run: |
+#           mkdir -p package/DEBIAN
+#           echo "Package: qETRC" > package/DEBIAN/control
+#           echo "Version: 1.0.0" >> package/DEBIAN/control
+#           echo "Section: base" >> package/DEBIAN/control
+#           echo "Priority: optional" >> package/DEBIAN/control
+#           echo "Architecture: amd64" >> package/DEBIAN/control
+#           echo "Maintainer: Your Name <your.email@example.com>" >> package/DEBIAN/control
+#           echo "Description: qETRC application" >> package/DEBIAN/control
+#           mkdir -p package/usr/local/bin
+#           cp build/qETRC package/usr/local/bin/
+#           dpkg-deb --build package qETRC-1.0.0.deb
+#
+#       - name: Upload .deb artifact
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: qETRC-deb
+#           path: qETRC-1.0.0.deb


### PR DESCRIPTION
自动构建 Linux 版本

这个版本的问题在于仍然需要 saribbon 以及 ads 作为前置库（会查找有没有这个库，如果没有安装则无法执行）。如果可以的话，希望有办法可以打包成 deb 格式的安装包。

除此之外，目前版本 ubuntu apt 库的 qt 版本过低（6.4.\*），因此在这个文件中我使用了手动安装 Qt 的方法（6.7.\*），需要提供对应的用户名和密码。
